### PR TITLE
SwiftLint 導入を含めたリファクタ対応

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,44 @@
+disabled_rules:
+  - todo
+opt_in_rules:
+  - closure_end_indentation
+  - closure_spacing
+  - conditional_returns_on_newline
+  - empty_count
+  - explicit_init
+  - force_unwrapping
+  - nimble_operator
+  - number_separator
+  - object_literal
+  - operator_usage_whitespace
+  - overridden_super_call
+  - prohibited_super_call
+  - redundant_nil_coalescing
+  - sorted_imports
+  - switch_case_on_newline
+included:
+excluded:
+  - Carthage
+  - Pods
+  - Source/ExcludedFolder
+  - Source/ExcludedFile.swift
+force_cast:
+  severity: warning
+force_try:
+  severity: warning
+line_length: 120
+type_body_length:
+  - 300
+  - 400
+file_length:
+  warning: 500
+  error: 1200
+type_name:
+  min_length: 4 # only warning
+  max_length: # warning and error
+    warning: 40
+    error: 50
+identifier_name:
+  excluded:
+    - id
+reporter: "xcode"

--- a/AikatsuLyric.xcodeproj/project.pbxproj
+++ b/AikatsuLyric.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		341AACF41E52D6ED00D04AF9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 341AACF31E52D6ED00D04AF9 /* Assets.xcassets */; };
 		341AACF71E52D6ED00D04AF9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 341AACF51E52D6ED00D04AF9 /* LaunchScreen.storyboard */; };
 		341AACFF1E52D8E800D04AF9 /* SongListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341AACFE1E52D8E800D04AF9 /* SongListTableViewController.swift */; };
+		3422CA5A1E5C07EF00DF8BC1 /* Song.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3422CA591E5C07EF00DF8BC1 /* Song.swift */; };
 		34C773771E53E8F600966F36 /* aikatsu_songs.json in Resources */ = {isa = PBXBuildFile; fileRef = 34C773761E53E8F600966F36 /* aikatsu_songs.json */; };
 /* End PBXBuildFile section */
 
@@ -27,6 +28,7 @@
 		341AACF61E52D6ED00D04AF9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		341AACF81E52D6ED00D04AF9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		341AACFE1E52D8E800D04AF9 /* SongListTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SongListTableViewController.swift; sourceTree = "<group>"; };
+		3422CA591E5C07EF00DF8BC1 /* Song.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Song.swift; sourceTree = "<group>"; };
 		34C773761E53E8F600966F36 /* aikatsu_songs.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = aikatsu_songs.json; sourceTree = "<group>"; };
 		3550AEE2AC88E9096FE882B6 /* Pods_AikatsuLyric.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AikatsuLyric.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84F23B35A71BFFD3A725A46F /* Pods-AikatsuLyric.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AikatsuLyric.release.xcconfig"; path = "Pods/Target Support Files/Pods-AikatsuLyric/Pods-AikatsuLyric.release.xcconfig"; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 				341AACEC1E52D6ED00D04AF9 /* AppDelegate.swift */,
 				341AACEE1E52D6ED00D04AF9 /* ViewController.swift */,
 				341AACF01E52D6ED00D04AF9 /* Main.storyboard */,
+				3422CA591E5C07EF00DF8BC1 /* Song.swift */,
 				341AACF31E52D6ED00D04AF9 /* Assets.xcassets */,
 				341AACF51E52D6ED00D04AF9 /* LaunchScreen.storyboard */,
 				341AACF81E52D6ED00D04AF9 /* Info.plist */,
@@ -181,7 +184,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		344E55561E5BF401007980D3 /* ShellScript */ = {
@@ -234,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3422CA5A1E5C07EF00DF8BC1 /* Song.swift in Sources */,
 				341AACFF1E52D8E800D04AF9 /* SongListTableViewController.swift in Sources */,
 				341AACEF1E52D6ED00D04AF9 /* ViewController.swift in Sources */,
 				341AACED1E52D6ED00D04AF9 /* AppDelegate.swift in Sources */,

--- a/AikatsuLyric.xcodeproj/project.pbxproj
+++ b/AikatsuLyric.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 				341AACE71E52D6ED00D04AF9 /* Resources */,
 				4E717FDBD77E2BAEC6F742C5 /* [CP] Embed Pods Frameworks */,
 				5B9B8DEED1A50A5799E11E57 /* [CP] Copy Pods Resources */,
+				344E55561E5BF401007980D3 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -130,6 +131,7 @@
 					341AACE81E52D6ED00D04AF9 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = UHB4CBC373;
+						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -179,8 +181,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		344E55561E5BF401007980D3 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which ${PODS_ROOT}/SwiftLint/swiftlint >/dev/null; then\n    ${PODS_ROOT}/SwiftLint/swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		4E717FDBD77E2BAEC6F742C5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -342,6 +357,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2997C005D1B2F0B0E8A989E5 /* Pods-AikatsuLyric.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = UHB4CBC373;
 				INFOPLIST_FILE = AikatsuLyric/Info.plist;
@@ -357,6 +373,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 84F23B35A71BFFD3A725A46F /* Pods-AikatsuLyric.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = UHB4CBC373;
 				INFOPLIST_FILE = AikatsuLyric/Info.plist;

--- a/AikatsuLyric/AppDelegate.swift
+++ b/AikatsuLyric/AppDelegate.swift
@@ -13,34 +13,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions
+        launchOptions: [UIApplicationLaunchOptionsKey: Any]?
+    ) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/AikatsuLyric/Song.swift
+++ b/AikatsuLyric/Song.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2017年 Tomohiro Zoda. All rights reserved.
 //
 
-//import Foundation
 import ObjectMapper
 
 struct Song: ImmutableMappable {

--- a/AikatsuLyric/Song.swift
+++ b/AikatsuLyric/Song.swift
@@ -1,0 +1,30 @@
+//
+//  Song.swift
+//  AikatsuLyric
+//
+//  Created by Tomohiro Zoda on 2017/02/21.
+//  Copyright © 2017年 Tomohiro Zoda. All rights reserved.
+//
+
+//import Foundation
+import ObjectMapper
+
+struct Song: ImmutableMappable {
+    let title: String
+    let text: String
+    let thumbnailUrl: String
+    let scene: String
+    let series: String
+    let singer: String
+    let embedMovieSrc: String
+
+    init(map: Map) throws {
+        title = try map.value("title")
+        text = try map.value("text")
+        thumbnailUrl = try map.value("thumbnail_url")
+        series = try map.value("series")
+        scene = try map.value("scene")
+        singer = try map.value("singer")
+        embedMovieSrc = try map.value("embed_movie_src")
+    }
+}

--- a/AikatsuLyric/SongListTableViewController.swift
+++ b/AikatsuLyric/SongListTableViewController.swift
@@ -6,19 +6,26 @@
 //  Copyright © 2017年 Tomohiro Zoda. All rights reserved.
 //
 
+import ObjectMapper
+import SCLAlertView
 import SwiftyJSON
 import UIKit
 
 class SongListTableViewController: UITableViewController {
 
-    var songs: JSON = []
+    var songs: [Song] = []
 
     // MARK: - Table view data source
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        songs = loadSongsJSON()!
+        do {
+            songs = try loadSongs()
+        } catch {
+            // 復帰不可のため、ポップアップでアプリ再起動を促す
+            SCLAlertView().showError("読み込みエラー", subTitle: "アプリを再度立ち上げ直してください。")
+        }
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -32,9 +39,9 @@ class SongListTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
         let song = songs[(indexPath as NSIndexPath).row]
-        let detailText = String(describing: song["series"]) + " - " + String(describing: song["scene"])
+        let detailText = song.series + " - " + song.scene
 
-        cell.textLabel?.text = String(describing: song["title"])
+        cell.textLabel?.text = song.title
         cell.detailTextLabel?.text = detailText
 
         return cell
@@ -46,26 +53,26 @@ class SongListTableViewController: UITableViewController {
         if segue.identifier == "showSongPage" {
             if let indexPath = self.tableView.indexPathForSelectedRow {
                 let song = songs[(indexPath as NSIndexPath).row]
-                (segue.destination as! ViewController).data = (
-                    title: String(describing: song["title"]),
-                    text: String(describing: song["text"]),
-                    thumbnail_url: String(describing: song["thumbnail_url"]),
-                    series: String(describing: song["series"]),
-                    scene: String(describing: song["scene"]),
-                    singer: String(describing: song["singer"]),
-                    embed_movie_src: String(describing: song["embed_movie_src"])
-                )
+                (segue.destination as! ViewController).song = song
             }
         }
     }
 
-    func loadSongsJSON() -> JSON? {
-        let path = Bundle.main.path(forResource: "aikatsu_songs", ofType: "json")
-        do {
-            let jsonStr = try String(contentsOfFile: path!)
-            return JSON.parse(jsonStr)
-        } catch {
-            return nil
+    func loadSongs() throws -> [Song] {
+        if let path = Bundle.main.path(forResource: "aikatsu_songs", ofType: "json"),
+           let json_data = FileManager.default.contents(atPath: path) {
+            let json = try JSONSerialization.jsonObject(
+                with: json_data,
+                options: JSONSerialization.ReadingOptions.allowFragments
+            ) as! [[String: Any]]
+            return try Mapper<Song>().mapArray(JSONArray: json)
+        } else {
+            throw CustomError.jsonImportFailed
         }
+    }
+
+    enum CustomError: Error {
+        case jsonImportFailed
+        case songsImportFailed
     }
 }

--- a/AikatsuLyric/SongListTableViewController.swift
+++ b/AikatsuLyric/SongListTableViewController.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2017年 Tomohiro Zoda. All rights reserved.
 //
 
-import UIKit
 import SwiftyJSON
+import UIKit
 
 class SongListTableViewController: UITableViewController {
 
     var songs: JSON = []
-    
+
     // MARK: - Table view data source
 
     override func viewDidLoad() {
@@ -20,7 +20,7 @@ class SongListTableViewController: UITableViewController {
 
         songs = loadSongsJSON()!
     }
-    
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
@@ -29,17 +29,17 @@ class SongListTableViewController: UITableViewController {
         return songs.count
     }
 
-    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
         let song = songs[(indexPath as NSIndexPath).row]
-        
+        let detailText = String(describing: song["series"]) + " - " + String(describing: song["scene"])
+
         cell.textLabel?.text = String(describing: song["title"])
-        cell.detailTextLabel?.text = String(describing: song["series"]) + " - " + String(describing: song["scene"])
-        
+        cell.detailTextLabel?.text = detailText
+
         return cell
     }
-    
+
     // MARK: - Navigation
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/AikatsuLyric/ViewController.swift
+++ b/AikatsuLyric/ViewController.swift
@@ -53,13 +53,13 @@ class ViewController: UIViewController, UIWebViewDelegate {
         
         // Youtube動画
         if !data!.embed_movie_src.isEmpty {
-            let url = NSURL(string: data!.embed_movie_src)
-            let request = NSURLRequest(url: url! as URL)
+            let url = URL(string: data!.embed_movie_src)
+            let request = URLRequest(url: url! as URL)
             
             self.youtubeMovieWebView.loadRequest(request as URLRequest)
         }
     }
-    private func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+    internal func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
         activityIndicator.startAnimating()
         return true
     }

--- a/AikatsuLyric/ViewController.swift
+++ b/AikatsuLyric/ViewController.swift
@@ -11,15 +11,7 @@ import UIKit
 
 class ViewController: UIViewController, UIWebViewDelegate {
 
-    var data: (
-        title: String,
-        text: String,
-        thumbnail_url: String,
-        series: String,
-        scene: String,
-        singer: String,
-        embed_movie_src: String
-    )?
+    var song: Song!
 
     @IBOutlet weak var songTitleLabel: UILabel!
     @IBOutlet weak var lyricTextView: UITextView!
@@ -38,24 +30,21 @@ class ViewController: UIViewController, UIWebViewDelegate {
         activityIndicator.hidesWhenStopped = true
         youtubeMovieWebView.delegate = self
 
-        songTitleLabel.text = data!.title
-        lyricTextView.text = data!.text
-        seriesLabel.text = data!.series
-        sceneLabel.text = data!.scene
-        singerLabel.text = data!.singer
+        songTitleLabel.text = song.title
+        lyricTextView.text = song.text
+        seriesLabel.text = song.series
+        sceneLabel.text = song.scene
+        singerLabel.text = song.singer
 
         // サムネイル画像
-        if !data!.thumbnail_url.isEmpty {
-            let url = URL(string: data!.thumbnail_url)
+        if let url = URL(string: song.thumbnailUrl) {
             let placeholderImage = #imageLiteral(resourceName: "NoImage")
             self.songThumbnailImage.kf.setImage(with: url, placeholder: placeholderImage)
         }
 
         // Youtube動画
-        if !data!.embed_movie_src.isEmpty {
-            let url = URL(string: data!.embed_movie_src)
-            let request = URLRequest(url: url! as URL)
-
+        if let srcUrl = URL(string: song.embedMovieSrc) {
+            let request = URLRequest(url: srcUrl)
             self.youtubeMovieWebView.loadRequest(request as URLRequest)
         }
     }
@@ -78,6 +67,5 @@ class ViewController: UIViewController, UIWebViewDelegate {
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
     }
 }

--- a/AikatsuLyric/ViewController.swift
+++ b/AikatsuLyric/ViewController.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017年 Tomohiro Zoda. All rights reserved.
 //
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class ViewController: UIViewController, UIWebViewDelegate {
 
@@ -43,31 +43,35 @@ class ViewController: UIViewController, UIWebViewDelegate {
         seriesLabel.text = data!.series
         sceneLabel.text = data!.scene
         singerLabel.text = data!.singer
-        
+
         // サムネイル画像
         if !data!.thumbnail_url.isEmpty {
             let url = URL(string: data!.thumbnail_url)
-            let placeholderImage = UIImage(named: "NoImage")
+            let placeholderImage = #imageLiteral(resourceName: "NoImage")
             self.songThumbnailImage.kf.setImage(with: url, placeholder: placeholderImage)
         }
-        
+
         // Youtube動画
         if !data!.embed_movie_src.isEmpty {
             let url = URL(string: data!.embed_movie_src)
             let request = URLRequest(url: url! as URL)
-            
+
             self.youtubeMovieWebView.loadRequest(request as URLRequest)
         }
     }
-    internal func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+    internal func webView(
+        _ webView: UIWebView,
+        shouldStartLoadWith request: URLRequest,
+        navigationType: UIWebViewNavigationType
+    ) -> Bool {
         activityIndicator.startAnimating()
         return true
     }
-    
+
     func webViewDidFinishLoad(_ webView: UIWebView) {
         activityIndicator.stopAnimating()
     }
-    
+
     func webViewDidStartLoad(_ webView: UIWebView) {
         activityIndicator.startAnimating()
     }
@@ -77,4 +81,3 @@ class ViewController: UIViewController, UIWebViewDelegate {
         // Dispose of any resources that can be recreated.
     }
 }
-

--- a/Podfile
+++ b/Podfile
@@ -2,10 +2,18 @@
 # platform :ios, '9.0'
 
 target 'AikatsuLyric' do
-  # Comment this line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
 
   # Pods for AikatsuLyric
   pod 'SwiftyJSON', '~> 3.0.0'
   pod 'Kingfisher', '~> 3.0'
+  pod 'SwiftLint'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['SWIFT_VERSION'] = '3.0'
+    end
+  end
 end

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,3 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
-
 target 'AikatsuLyric' do
   use_frameworks!
 
@@ -8,6 +5,8 @@ target 'AikatsuLyric' do
   pod 'SwiftyJSON', '~> 3.0.0'
   pod 'Kingfisher', '~> 3.0'
   pod 'SwiftLint'
+  pod 'ObjectMapper'
+  pod 'SCLAlertView'
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,24 @@
 PODS:
   - Kingfisher (3.4.0)
+  - ObjectMapper (2.2.2)
+  - SCLAlertView (0.7.0)
   - SwiftLint (0.16.1)
   - SwiftyJSON (3.0.0)
 
 DEPENDENCIES:
   - Kingfisher (~> 3.0)
+  - ObjectMapper
+  - SCLAlertView
   - SwiftLint
   - SwiftyJSON (~> 3.0.0)
 
 SPEC CHECKSUMS:
   Kingfisher: 5690cfb3d1bddf3a98d679a3a34d0b7294974ed2
+  ObjectMapper: 9e385c2295bcc4e16eabbcfc85db801442bba545
+  SCLAlertView: 8a14ffc40590c619e183eed2298b854385f30be1
   SwiftLint: b8b683208cc09640898f16318a7a452274e91f61
   SwiftyJSON: f57b2b44bc166617372d1c70773591fe9f0f5fd4
 
-PODFILE CHECKSUM: eaec670e7ca619a537757c6778a23d4ee0f702df
+PODFILE CHECKSUM: 12de522c07f13c6761ee1553a74b2beddb211a6d
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.2.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,18 @@
 PODS:
   - Kingfisher (3.4.0)
+  - SwiftLint (0.16.1)
   - SwiftyJSON (3.0.0)
 
 DEPENDENCIES:
   - Kingfisher (~> 3.0)
+  - SwiftLint
   - SwiftyJSON (~> 3.0.0)
 
 SPEC CHECKSUMS:
   Kingfisher: 5690cfb3d1bddf3a98d679a3a34d0b7294974ed2
+  SwiftLint: b8b683208cc09640898f16318a7a452274e91f61
   SwiftyJSON: f57b2b44bc166617372d1c70773591fe9f0f5fd4
 
-PODFILE CHECKSUM: 5b9ca8858dc02bf58f01528c7943c6c99f869fc4
+PODFILE CHECKSUM: eaec670e7ca619a537757c6778a23d4ee0f702df
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.0.1


### PR DESCRIPTION
## 背景
下記の Issue に対応した。
fixed #3 SwiftLint を導入したい
fixed #4 SwiftLint に則って Caution 対応したい
fixed #5 Song のデータの型(Entity)を定義して持ち回したい

## TODO リスト
- [x] SwiftLint 導入
  - .swiftlint.yml 導入
    - 参考: http://qiita.com/KAGE_MIKU/items/80e6d905dc0059c342b3
- [x] SwiftLint に則って Caution 対応
  - 一部 force_unwrapping を除いて対応
    - <img src="https://cloud.githubusercontent.com/assets/1973683/23153863/27eb81e6-f84e-11e6-86ca-bdd0f1d5fc21.png" width=300px;>

- [x] Song Entity を切り出し
  - ObjectMapper を利用
    - https://github.com/Hearst-DD/ObjectMapper

## ほかに気になっていること
- [x] テストどうするんだっけ
   - Swift の UnitTest は Quick でよさそう
     - http://grandbig.github.io/blog/2016/01/16/quick/
  - E2E は Appium よさそう
     - https://speakerdeck.com/jollyjoester/reproniokeruappiumfalsehuo-yong-shi-li
- [x] 残された force_unwrapping の対処法
  - 自分で設計したオプショナルなら回避できるはず、組み込み API が返すような挽回不可な nil は意図的にクラッシュさせるのであれば OK
- [x] swiftlint.yml のおすすめ
  - まずは自分のコーディング規約の思想に基づく範囲でフル適用、その後妥協していく
- [x] アプリにおける例外のレスキューのお作法
  - （webも同じだが）握り潰さないこと
    - ハンドリングの思想に関しては [こちら](https://ez-net.jp/article/B2/cwtBwURB/pp3ZiIOQz2Cc/)
       - Result 型使いたい時は [こちら](https://github.com/antitypical/Result)

## 備考
* ユーザーへの警告のために [SCLAlertView](https://github.com/dogo/SCLAlertView) を利用
  - <img src="https://cloud.githubusercontent.com/assets/1973683/23153808/dd9b4dc4-f84d-11e6-821f-9617819ed9d8.PNG" width=300px;>
