### PR TITLE
force_cast の警告を解消する

### DIFF
--- a/AikatsuLyric/SongListTableViewController.swift
+++ b/AikatsuLyric/SongListTableViewController.swift
@@ -55,8 +55,8 @@ class SongListTableViewController: UITableViewController {
         if segue.identifier == "showSongPage" {
             if let indexPath = self.tableView.indexPathForSelectedRow {
                 let song = songs[(indexPath as NSIndexPath).row]
-                if let nextViewController = segue.destination as? ViewController {
-                    nextViewController.song = song
+                if let destinationViewController = segue.destination as? ViewController {
+                    destinationViewController.song = song
                 }
             }
         }

--- a/AikatsuLyric/SongListTableViewController.swift
+++ b/AikatsuLyric/SongListTableViewController.swift
@@ -12,6 +12,7 @@ import SwiftyJSON
 import UIKit
 
 class SongListTableViewController: UITableViewController {
+    typealias JSONObject = [String: Any]
 
     var songs: [Song] = []
 
@@ -24,7 +25,7 @@ class SongListTableViewController: UITableViewController {
             songs = try loadSongs()
         } catch {
             // 復帰不可のため、ポップアップでアプリ再起動を促す
-            SCLAlertView().showError("読み込みエラー", subTitle: "アプリを再度立ち上げ直してください。")
+            SCLAlertView().showError("読み込みエラー", subTitle: "アプリを再起動してください。")
         }
     }
 
@@ -37,7 +38,11 @@ class SongListTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "SongCell", for: indexPath) as! SongListTableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "SongCell", for: indexPath)
+            as? SongListTableViewCell else {
+
+            abort() // Identifier の定義が誤っている場合に検知のために落とす
+        }
         let song = songs[(indexPath as NSIndexPath).row]
         cell.apply(song: song)
 
@@ -50,25 +55,27 @@ class SongListTableViewController: UITableViewController {
         if segue.identifier == "showSongPage" {
             if let indexPath = self.tableView.indexPathForSelectedRow {
                 let song = songs[(indexPath as NSIndexPath).row]
-                (segue.destination as! ViewController).song = song
+                if let nextViewController = segue.destination as? ViewController {
+                    nextViewController.song = song
+                }
             }
         }
     }
 
     func loadSongs() throws -> [Song] {
-        if let path = Bundle.main.path(forResource: "aikatsu_songs", ofType: "json"),
-           let json_data = FileManager.default.contents(atPath: path) {
-            let json = try JSONSerialization.jsonObject(
+        guard let path = Bundle.main.path(forResource: "aikatsu_songs", ofType: "json"),
+              let json_data = FileManager.default.contents(atPath: path),
+              let json = try JSONSerialization.jsonObject(
                 with: json_data,
                 options: JSONSerialization.ReadingOptions.allowFragments
-            ) as! [[String: Any]]
-            return try Mapper<Song>().mapArray(JSONArray: json)
-        } else {
-            throw JsonError.importFailed
+              ) as? [JSONObject]
+        else {
+            throw JSONError.importFailed
         }
+        return try Mapper<Song>().mapArray(JSONArray: json)
     }
 
-    enum JsonError: Error {
+    enum JSONError: Error {
         case importFailed
     }
 }


### PR DESCRIPTION
## 概要
残っていた SwiftLint の警告である force_cast に関して解消する。
fixed #7 

## TODO リスト
- [x] tableView.dequeueReusableCell(withIdentifier: "SongCell", for: indexPath)
  - 落ちるとしたら withIdentifier の設定ミスのため、復帰させようとせず abort() で落とす
- [x] (segue.destination as! ViewController).song = song
  - 普通にアンラップする
- [x] JSONSerialization.jsonObject...
  - JSON インポートに直結する部分を guard で包み、ダメだった場合は一括で throw
  - [JSONObject] でアンラップしていて ObjectMapper で死ぬことはないと思うのでそこは外出しして try している

## 質問事項
- [x] 上記の方針で問題ないかどうか